### PR TITLE
libc: Fix duplicate definition issue

### DIFF
--- a/libc/include/sched.h
+++ b/libc/include/sched.h
@@ -96,10 +96,14 @@ __BEGIN_DECLS
  * See sched_getparam()/sched_setparam() and
  * sched_getscheduler()/sched_setscheduler().
  */
+#ifndef __SCHED_PARAM_DEFINED
+#define __SCHED_PARAM_DEFINED
+#ifndef _LINUX_SCHED_TYPES_H
 struct sched_param {
   int sched_priority;
 };
-
+#endif
+#endif
 /**
  * [sched_setscheduler(2)](https://man7.org/linux/man-pages/man2/sched_setscheduler.2.html)
  * sets the scheduling policy and associated parameters for the given thread.


### PR DESCRIPTION
This change addresses a problem where the sched_param struct was being redefined across multiple headers. By adding the necessary header guards (#ifndef __SCHED_PARAM_DEFINED and #ifndef _LINUX_SCHED_TYPES_H), we ensure that the struct is only defined once, preventing conflicts and redefinition errors. This fix enhances compatibility, especially in build systems or configurations that include different scheduling-related headers, ensuring a smoother integration without definition clashes.